### PR TITLE
feat: E2Eテスト基盤構築（Playwright）

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -39,3 +39,9 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.auth/

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -331,6 +332,8 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 
@@ -828,7 +831,7 @@
 
     "fs-extra": ["fs-extra@11.3.3", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1093,6 +1096,10 @@
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
+
+    "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
@@ -1414,6 +1421,8 @@
 
     "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
+    "rollup/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -1421,6 +1430,8 @@
     "sharp/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -1,0 +1,10 @@
+import path from "node:path";
+import { test as setup } from "@playwright/test";
+import { login } from "./helpers/login";
+
+const authFile = path.join(__dirname, "../playwright/.auth/user.json");
+
+setup("SALES ユーザーで認証状態を保存", async ({ page }) => {
+  await login(page, "sales");
+  await page.context().storageState({ path: authFile });
+});

--- a/frontend/e2e/fixtures/test-data.ts
+++ b/frontend/e2e/fixtures/test-data.ts
@@ -1,0 +1,43 @@
+/**
+ * E2Eテスト用テストデータ定義
+ *
+ * テスト仕様書（TEST_DEFINITION.md）のテストデータ定義に基づく。
+ * 実際のデータ投入はバックエンド側のシーダーまたはAPIを通じて行う。
+ * ここではテストコード内で参照する定数を定義する。
+ */
+
+/** テスト用顧客データ */
+export const TEST_CUSTOMERS = {
+  C001: {
+    company_name: "○○株式会社",
+    contact_name: "佐藤一郎",
+    phone: "03-1111-2222",
+    email: "sato@oo.co.jp",
+  },
+  C002: {
+    company_name: "△△商事",
+    contact_name: "伊藤二郎",
+    phone: "06-3333-4444",
+    email: "ito@sankaku.co.jp",
+  },
+  C003: {
+    company_name: "□□工業",
+    contact_name: "渡辺三郎",
+    phone: "052-5555-6666",
+    email: "watanabe@shiro.co.jp",
+  },
+} as const;
+
+/** テスト用日報ステータス */
+export const REPORT_STATUS = {
+  DRAFT: "DRAFT",
+  SUBMITTED: "SUBMITTED",
+  REVIEWED: "REVIEWED",
+} as const;
+
+/** ステータスの日本語表示 */
+export const STATUS_LABELS = {
+  DRAFT: "下書き",
+  SUBMITTED: "提出済み",
+  REVIEWED: "確認済み",
+} as const;

--- a/frontend/e2e/helpers/login.ts
+++ b/frontend/e2e/helpers/login.ts
@@ -1,0 +1,38 @@
+import type { Page } from "@playwright/test";
+
+/** テスト用ユーザー情報 */
+export const TEST_USERS = {
+  sales: {
+    email: "tanaka@example.com",
+    password: "password123",
+    name: "田中太郎",
+    role: "SALES" as const,
+  },
+  manager: {
+    email: "yamada@example.com",
+    password: "password123",
+    name: "山田部長",
+    role: "MANAGER" as const,
+  },
+} as const;
+
+type TestUserKey = keyof typeof TEST_USERS;
+
+/**
+ * 指定したユーザーでログインする
+ * ログインフォームに入力し、日報一覧画面への遷移を待つ
+ */
+export async function login(
+  page: Page,
+  userKey: TestUserKey = "sales",
+): Promise<void> {
+  const user = TEST_USERS[userKey];
+
+  await page.goto("/login");
+  await page.getByLabel("メールアドレス").fill(user.email);
+  await page.getByLabel("パスワード").fill(user.password);
+  await page.getByRole("button", { name: "ログイン" }).click();
+
+  // ログイン成功後、日報一覧画面に遷移するまで待機
+  await page.waitForURL("/reports");
+}

--- a/frontend/e2e/helpers/setup-data.ts
+++ b/frontend/e2e/helpers/setup-data.ts
@@ -1,0 +1,104 @@
+/**
+ * E2Eテスト用データのセットアップ/クリーンアップ
+ *
+ * バックエンドAPIを直接呼び出してテストデータを投入・削除する。
+ * Playwright の globalSetup / globalTeardown や各テストの beforeAll/afterAll で使用する。
+ */
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8000";
+
+type ApiResponse<T> = { data: T };
+
+/**
+ * バックエンドAPIにリクエストを送信するヘルパー
+ * テストデータ操作はサーバーサイドで行うため、Cookie ではなくトークンを直接使用する
+ */
+async function apiRequest<T>(
+  method: string,
+  path: string,
+  options?: { body?: unknown; token?: string },
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (options?.token) {
+    headers.Cookie = `access_token=${options.token}`;
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/v1${path}`, {
+    method,
+    headers,
+    body: options?.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    throw new Error(
+      `API request failed: ${method} ${path} - ${response.status}: ${errorBody}`,
+    );
+  }
+
+  if (response.status === 204) {
+    return undefined as T;
+  }
+
+  return response.json();
+}
+
+/**
+ * テストユーザーとしてログインし、認証トークンを取得する
+ */
+export async function getAuthToken(
+  email: string,
+  password: string,
+): Promise<string> {
+  const response = await fetch(`${API_BASE_URL}/api/v1/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Login failed for ${email}: ${response.status}`);
+  }
+
+  // httpOnly Cookie からトークンを取得
+  const setCookie = response.headers.get("set-cookie");
+  const tokenMatch = setCookie?.match(/access_token=([^;]+)/);
+  if (!tokenMatch) {
+    throw new Error("access_token が Set-Cookie ヘッダーに含まれていません");
+  }
+
+  return tokenMatch[1];
+}
+
+/**
+ * テスト用顧客データを作成する
+ */
+export async function createTestCustomer(
+  token: string,
+  data: {
+    company_name: string;
+    contact_name: string;
+    phone?: string;
+    email?: string;
+    address?: string;
+  },
+): Promise<{ id: number }> {
+  const res = await apiRequest<ApiResponse<{ id: number }>>(
+    "POST",
+    "/customers",
+    { body: data, token },
+  );
+  return res.data;
+}
+
+/**
+ * テスト用顧客データを削除する
+ */
+export async function deleteTestCustomer(
+  token: string,
+  customerId: number,
+): Promise<void> {
+  await apiRequest("DELETE", `/customers/${customerId}`, { token });
+}

--- a/frontend/e2e/login.spec.ts
+++ b/frontend/e2e/login.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { TEST_USERS } from "./helpers/login";
+
+// ログインテストは認証不要の状態で実行する
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("ログイン画面 (SCR-LOGIN)", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/login");
+  });
+
+  test("AUTH-001: 正常ログイン（SALES）", async ({ page }) => {
+    const user = TEST_USERS.sales;
+
+    await page.getByLabel("メールアドレス").fill(user.email);
+    await page.getByLabel("パスワード").fill(user.password);
+    await page.getByRole("button", { name: "ログイン" }).click();
+
+    await expect(page).toHaveURL("/reports");
+  });
+
+  test("AUTH-002: 正常ログイン（MANAGER）", async ({ page }) => {
+    const user = TEST_USERS.manager;
+
+    await page.getByLabel("メールアドレス").fill(user.email);
+    await page.getByLabel("パスワード").fill(user.password);
+    await page.getByRole("button", { name: "ログイン" }).click();
+
+    await expect(page).toHaveURL("/reports");
+  });
+
+  test("AUTH-003: 誤パスワードでログイン失敗", async ({ page }) => {
+    await page.getByLabel("メールアドレス").fill(TEST_USERS.sales.email);
+    await page.getByLabel("パスワード").fill("wrongpass");
+    await page.getByRole("button", { name: "ログイン" }).click();
+
+    await expect(
+      page.getByText("メールアドレスまたはパスワードが正しくありません"),
+    ).toBeVisible();
+  });
+
+  test("AUTH-008: 未認証時のリダイレクト", async ({ page }) => {
+    await page.goto("/reports");
+
+    await expect(page).toHaveURL("/login");
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "biome check .",
     "test": "vitest run",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:debug": "playwright test --debug",
     "generate:types": "openapi-typescript http://localhost:8000/openapi.json -o src/types/api.d.ts"
   },
   "dependencies": {
@@ -27,6 +30,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const BASE_URL = "http://localhost:3000";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? "github" : "html",
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "setup",
+      testMatch: /.*\.setup\.ts/,
+    },
+    {
+      name: "chromium",
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: "playwright/.auth/user.json",
+      },
+      dependencies: ["setup"],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary
- Playwright によるE2Eテスト環境を構築
- ログイン認証ヘルパー・テストデータ管理・サンプルテストを実装
- `bun run e2e` でテスト実行可能

## 変更内容
- `@playwright/test` のインストールと `playwright.config.ts` の設定（Chromium、storageState による認証状態再利用）
- `e2e/` ディレクトリ構成の作成（helpers, fixtures）
- テスト用ログインヘルパー（`e2e/helpers/login.ts`）と認証セットアップ（`e2e/auth.setup.ts`）
- テストデータのセットアップ/クリーンアップスクリプト（`e2e/helpers/setup-data.ts`）
- ログイン画面のサンプルE2Eテスト（`e2e/login.spec.ts`）— AUTH-001, 002, 003, 008
- `package.json` に `e2e` / `e2e:ui` / `e2e:debug` スクリプトを追加
- `.gitignore` に Playwright 関連の除外設定を追加

## Test plan
- [x] `bun run e2e --list` でテストファイルが正しく認識される
- [x] `bun run test` で既存 Vitest テストが全件パス（64/64）
- [ ] バックエンド起動状態で `bun run e2e` を実行しテストがパスすること

closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)